### PR TITLE
Fix README DOI badge

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -17,7 +17,7 @@ knitr::opts_chunk$set(
 
 # anicheck
 <!-- badges: start -->
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.17357778.svg)](https://doi.org/10.5281/zenodo.17357778)
+[![DOI](https://zenodo.org/badge/1076684950.svg)](https://doi.org/10.5281/zenodo.21033042)
 [![R-CMD-check](https://github.com/animovement/anicheck/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/animovement/anicheck/actions/workflows/R-CMD-check.yaml)
 [![anicheck status
 badge](https://animovement.r-universe.dev/badges/anicheck)](https://animovement.r-universe.dev)

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 <!-- badges: start -->
 
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.17357778.svg)](https://doi.org/10.5281/zenodo.17357778)
+[![DOI](https://zenodo.org/badge/1076684950.svg)](https://doi.org/10.5281/zenodo.21033042)
 [![R-CMD-check](https://github.com/animovement/anicheck/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/animovement/anicheck/actions/workflows/R-CMD-check.yaml)
 [![anicheck status
 badge](https://animovement.r-universe.dev/badges/anicheck)](https://animovement.r-universe.dev)


### PR DESCRIPTION
Updates the DOI badge to point at the correct Zenodo record:

[![DOI](https://zenodo.org/badge/1076684950.svg)](https://doi.org/10.5281/zenodo.21033042)

Replaces the stale `10.5281/zenodo.17357778` badge in both `README.Rmd` and the generated `README.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)