### PR TITLE
Call the shared check workflows

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -1,64 +1,16 @@
-# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
-# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+# Runs R CMD check. The workflow lives in animovement/.github so it is
+# maintained in one place; only the triggers are declared here, because GitHub
+# fires them against this repository.
+name: R-CMD-check
+
 on:
   push:
     branches: [main, master]
   pull_request:
 
-name: R-CMD-check.yaml
-
 permissions: read-all
 
 jobs:
   R-CMD-check:
-    runs-on: ${{ matrix.config.os }}
-
-    name: ${{ matrix.config.os }} (${{ matrix.config.r }})
-
-    strategy:
-      fail-fast: false
-      matrix:
-        # R-devel has no binaries, so it runs on merges to main, not on PRs.
-        config: >-
-          ${{ github.event_name == 'pull_request'
-          && fromJSON('[
-            {"os": "macos-latest", "r": "release"},
-            {"os": "windows-latest", "r": "release"},
-            {"os": "ubuntu-latest", "r": "release"},
-            {"os": "ubuntu-latest", "r": "oldrel-1"}
-          ]')
-          || fromJSON('[
-            {"os": "macos-latest", "r": "release"},
-            {"os": "windows-latest", "r": "release"},
-            {"os": "ubuntu-latest", "r": "devel", "http-user-agent": "release"},
-            {"os": "ubuntu-latest", "r": "release"},
-            {"os": "ubuntu-latest", "r": "oldrel-1"}
-          ]') }}
-
-    env:
-      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
-      R_KEEP_PKG_SOURCE: yes
-      # renv's autoloader overrides options(repos), forcing source installs.
-      RENV_CONFIG_AUTOLOADER_ENABLED: false
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: r-lib/actions/setup-pandoc@v2
-
-      - uses: r-lib/actions/setup-r@v2
-        with:
-          r-version: ${{ matrix.config.r }}
-          http-user-agent: ${{ matrix.config.http-user-agent }}
-          use-public-rspm: true
-          extra-repositories: 'https://animovement.r-universe.dev'
-
-      - uses: r-lib/actions/setup-r-dependencies@v2
-        with:
-          extra-packages: any::rcmdcheck
-          needs: check
-
-      - uses: r-lib/actions/check-r-package@v2
-        with:
-          upload-snapshots: true
-          build_args: 'c("--no-manual","--compact-vignettes=gs+qpdf")'
+    uses: animovement/.github/.github/workflows/r-cmd-check.yml@main
+    secrets: inherit

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -1,5 +1,8 @@
-# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
-# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+# Builds and deploys the pkgdown site. The workflow lives in
+# animovement/.github so it is maintained in one place; only the triggers are
+# declared here.
+name: pkgdown
+
 on:
   push:
     branches: [main]
@@ -9,43 +12,11 @@ on:
     types: [published]
   workflow_dispatch:
 
-name: pkgdown
-
 jobs:
   pkgdown:
-    runs-on: ubuntu-latest
-    # Only restrict concurrency for non-PR jobs
-    concurrency:
-      group: pkgdown-${{ github.event_name != 'pull_request' || github.run_id }}
-    env:
-      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
-      # renv's autoloader overrides options(repos), forcing source installs.
-      RENV_CONFIG_AUTOLOADER_ENABLED: false
+    uses: animovement/.github/.github/workflows/pkgdown.yml@main
+    with:
+      quarto: false
     permissions:
       contents: write
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: r-lib/actions/setup-pandoc@v2
-
-      - uses: r-lib/actions/setup-r@v2
-        with:
-          use-public-rspm: true
-          extra-repositories: 'https://animovement.r-universe.dev'
-
-      - uses: r-lib/actions/setup-r-dependencies@v2
-        with:
-          extra-packages: any::pkgdown, local::.
-          needs: website
-
-      - name: Build site
-        run: pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE)
-        shell: Rscript {0}
-
-      - name: Deploy to GitHub pages 🚀
-        if: github.event_name != 'pull_request'
-        uses: JamesIves/github-pages-deploy-action@v4.5.0
-        with:
-          clean: false
-          branch: gh-pages
-          folder: docs
+    secrets: inherit

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -1,66 +1,15 @@
-# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
-# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+# Reports test coverage to Codecov. The workflow lives in animovement/.github
+# so it is maintained in one place; only the triggers are declared here.
+name: test-coverage
+
 on:
   push:
     branches: [main, master]
   pull_request:
 
-name: test-coverage.yaml
-
 permissions: read-all
 
 jobs:
   test-coverage:
-    runs-on: ubuntu-latest
-    env:
-      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
-      # renv's autoloader overrides options(repos), forcing source installs.
-      RENV_CONFIG_AUTOLOADER_ENABLED: false
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: r-lib/actions/setup-r@v2
-        with:
-          use-public-rspm: true
-          extra-repositories: 'https://animovement.r-universe.dev'
-
-      - uses: r-lib/actions/setup-r-dependencies@v2
-        with:
-          extra-packages: any::covr, any::xml2
-          needs: coverage
-
-      - name: Test coverage
-        run: |
-          cov <- covr::package_coverage(
-            quiet = FALSE,
-            clean = FALSE,
-            install_path = file.path(normalizePath(Sys.getenv("RUNNER_TEMP"), winslash = "/"), "package")
-          )
-          print(cov)
-          covr::to_cobertura(cov)
-        shell: Rscript {0}
-
-      - uses: codecov/codecov-action@v5
-        with:
-          # Fail if error if not on PR, or if on PR and token is given
-          fail_ci_if_error: ${{ github.event_name != 'pull_request' || secrets.CODECOV_TOKEN }}
-          files: ./cobertura.xml
-          plugins: noop
-          disable_search: true
-          token: ${{ secrets.CODECOV_TOKEN }}
-          slug: animovement/anicheck
-
-      - name: Show testthat output
-        if: always()
-        run: |
-          ## --------------------------------------------------------------------
-          find '${{ runner.temp }}/package' -name 'testthat.Rout*' -exec cat '{}' \; || true
-        shell: bash
-
-      - name: Upload test results
-        if: failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: coverage-test-failures
-          path: ${{ runner.temp }}/package
+    uses: animovement/.github/.github/workflows/test-coverage.yml@main
+    secrets: inherit


### PR DESCRIPTION
Replaces this repository's copies of `R-CMD-check`, `pkgdown` and `test-coverage` with stubs that call the shared workflows in [`animovement/.github`](https://github.com/animovement/.github/pull/3). About 180 lines become about 45, and the behaviour changes in one place for all eight packages.

**Merge [animovement/.github#3](https://github.com/animovement/.github/pull/3) first.** These stubs fail until the shared workflows are on `main` there.

Only the triggers stay here — GitHub fires those against this repository, so they cannot be centralised. Everything else moves.

## What changed for this package

All 24 workflow files across the eight packages were diffed first. The variation turned out to be almost nil: six of eight `R-CMD-check` files were byte-identical, and the rest differed only in comment length, a missing `extra-repositories` line, and a hardcoded Codecov `slug`. Two genuine differences are preserved as configuration:

- **Quarto** is installed only where vignettes or articles are `.qmd` — `animovement` and `aniframe` — via the `quarto` input on the pkgdown stub.
- **The Codecov `slug`** now comes from `${{ github.repository }}` rather than being hardcoded, so each package reports against itself. This also fixes `anivis` and `aniprocess`, which had no `slug` at all.

## Note on check names

Checks are now reported as `R-CMD-check / ubuntu-latest (release)` rather than `ubuntu-latest (release)`, because that is how reusable workflows are named. No repository in the organisation has branch protection or rulesets, so nothing depends on the old names — but worth knowing if required status checks are added later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
