### PR TITLE
chore: pin roxygen2 at 8.1.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,4 +34,4 @@ Config/Needs/website: animovement/animovementtemplate
 Config/testthat/edition: 3
 Roxygen: list(markdown = TRUE)
 VignetteBuilder: knitr
-Config/roxygen2/version: 8.0.0
+Config/roxygen2/version: 8.1.0

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -18,5 +18,7 @@ S3method(summary,check_na_timing)
 export(check_confidence)
 export(check_na_gapsize)
 export(check_na_timing)
-importFrom(rlang,":=")
-importFrom(rlang,.data)
+importFrom(rlang,
+  ":=",
+  .data
+)


### PR DESCRIPTION
## Description

### What kind of change is this?

- [ ] Bug fix
- [ ] Addition of a new feature
- [ ] Documentation
- [x] Maintenance (CI, dependencies, refactoring)
- [ ] Other

### Why is it needed?

The suite was split across three roxygen versions:

| Version | Packages |
|---|---|
| `Config/roxygen2/version: 8.1.0` | aniframe, aniread, aniprocess, animetric, animovement |
| `Config/roxygen2/version: 8.0.0` | anivis, anicheck |
| `RoxygenNote: 7.3.3` | anispace |

The cost is not cosmetic. Whoever runs `devtools::document()` next gets regenerated files in their diff whether or not they touched the documentation, and then has to decide whether that hunk belongs in their pull request. It does not — so it gets reverted, and the staleness survives to bite the next person. I hit exactly this twice while adding examples.

**8.1.0** because it is already the majority.

### What does it do?

Bumps `Config/roxygen2/version` from 8.0.0 to 8.1.0 and regenerates. The only regenerated change is `NAMESPACE`, where 8.1.0 writes a multi-line `importFrom` in place of one line per import:

```diff
-importFrom(rlang,":=")
-importFrom(rlang,.data)
+importFrom(rlang,
+  ":=",
+  .data
+)
```

Same imports, different formatting. No `man/` file changed, so no documentation content is affected.

## References

Part of standardising roxygen across the suite — sibling pull requests in the other affected packages, plus one in aniframe for a stale generated file there.

## Is this a breaking change?

No. A version field and a formatting change to generated `NAMESPACE` output.

## Does this PR require a documentation update?

No.

## Checklist

- [x] Tests pass locally (`devtools::test()`) — 74 passing
- [ ] Tests have been added covering new functionality — N/A
- [x] Documentation regenerated if roxygen comments changed (`devtools::document()`)
- [x] Code is formatted with [air](https://posit-dev.github.io/air/)
- [ ] A `NEWS.md` bullet added under `# (development version)` — N/A, no user-facing change
- [x] I have read and understood every change I am submitting, and tested it myself

🤖 Generated with [Claude Code](https://claude.com/claude-code)
