### PR TITLE
docs: open the development version and record the carried declarations

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: anicheck
 Type: Package
 Title: An R package for diagnosing movement data quality
-Version: 0.2.0
+Version: 0.2.0.9000
 Authors@R: 
     person(
       "Mikkel", 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# anicheck (development version)
+
+## New features
+
+* Check objects now carry the aniframe declarations they were built from, as `variables_what` and `variables_when` attributes (animovement/anivis#21). `group_cols` concatenates identity and temporal context, so a consumer given only that vector cannot tell where one ends and the other begins — "the last grouping column" can land on a session rather than the finest identity. The two fields travel under the names aniframe gives them, so `group_cols` keeps its meaning and is now fully explained by the attributes beside it.
+
 # anicheck 0.2.0
 
 ## New features


### PR DESCRIPTION
## Description

### What kind of change is this?

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Documentation
- [x] Maintenance (CI, dependencies, refactoring)
- [ ] Other

### Why is it needed?

#22 added `variables_what` and `variables_when` to check objects and was merged with the `NEWS.md` box marked N/A. **That was wrong twice over.**

It *is* a user-facing change: it alters what `check_confidence()`, `check_na_gapsize()` and `check_na_timing()` return, and anyone inspecting the attributes — or writing their own plotting on top of a check object — can read them.

And the reason I gave for skipping it was that no `# (development version)` section existed. That is a reason to **open** the section, not to skip the entry. `DESCRIPTION` also sat at the released `0.2.0` with no `.9000`, so there was nowhere for a bullet to go.

### What does it do?

- `DESCRIPTION` → `0.2.0.9000`, the released version plus `.9000`, matching aniframe and anispace.
- `NEWS.md` opens `# anicheck (development version)` with a bullet for #22.

This is the post-release step from the release checklist, which looks to have been missed after 0.2.0 — the same gap animovement/anispace#22 closed for anispace.

## References

Follows #22. Sibling change in animovement/anivis#25, which had the same gap.

## How has this PR been tested?

`DESCRIPTION` and `NEWS.md` only; no code. Verified R reads the version as a development one:

```r
> v <- read.dcf("DESCRIPTION")[, "Version"]; v
[1] "0.2.0.9000"
> unclass(package_version(v))[[1]][4] >= 9000
[1] TRUE
```

## Is this a breaking change?

No.

## Does this PR require a documentation update?

This is the documentation update.

## Checklist

- [x] Tests pass locally (`devtools::test()`) — unchanged by this PR; no R code touched
- [ ] Tests have been added covering new functionality — N/A
- [ ] Documentation regenerated if roxygen comments changed — N/A
- [x] Code is formatted — `DESCRIPTION` and `NEWS.md` only
- [x] A `NEWS.md` bullet added under `# (development version)` — this PR creates the section
- [x] I have read and understood every change I am submitting, and tested it myself

🤖 Generated with [Claude Code](https://claude.com/claude-code)
