### PR TITLE
chore: release 0.3.0

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,8 +8,8 @@ message: 'To cite package "anicheck" in publications use:'
 type: software
 license: MIT
 title: 'anicheck: An R package for diagnosing movement data quality.'
-version: 0.2.0
-date-released: 2025-10-21
+version: 0.3.0
+date-released: 2026-08-28
 identifiers:
   - type: doi
     value: 10.5281/zenodo.21033042

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: anicheck
 Type: Package
 Title: An R package for diagnosing movement data quality
-Version: 0.2.0.9000
+Version: 0.3.0
 Authors@R: 
     person(
       "Mikkel", 
@@ -19,7 +19,7 @@ LazyData: true
 Depends:
     R (>= 4.1.0)
 Imports:
-    anicore,
+    anicore (>= 0.8.0),
     cli,
     rlang,
     stats,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
-# anicheck (development version)
+# anicheck 0.3.0 (2026-08-28)
 
 ## Changed
+
+* The minimum `anicore` is 0.8.0, the first version published under that name — the dependency was renamed without a version constraint, so nothing recorded that a pre-rename `aniframe` will not do.
 
 * The core data structures come from `anicore`, which is what the `aniframe` package was renamed to in its 0.8.0 (animovement/anicore#84). The `aniframe` class keeps its name; only the package providing it changed, so `anicore` replaces `aniframe` in `Imports` and in every `aniframe::` call.
 


### PR DESCRIPTION
## Description

### What kind of change is this?

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Documentation
- [x] Maintenance (CI, dependencies, refactoring)
- [ ] Other

### Why is it needed?

Cuts anicheck 0.3.0. Minor, because check objects now carry the aniframe declarations they were built from.

### What does it do?

Bumps `DESCRIPTION`, `CITATION.cff` and the `NEWS.md` heading, and gives the anicore dependency the version constraint it never had.

anicheck was one of only two packages whose unreleased changelog needed nothing — the entries were already there and written for users.

### The anicore dependency had no version constraint

Just `anicore`, with nothing recording that a pre-rename `aniframe` will not do. Now `>= 0.8.0`, the first release published under that name — 0.6.0 and 0.7.0 were `aniframe`.

`CITATION.cff` also still carried `date-released: 2025-10-21`, ten months stale.

### References

Release checklist: #26.

## How has this PR been tested?

**78 tests pass**, 0 failures. `R CMD check` is **0 errors, 0 warnings, 0 notes**. `README.md` re-rendered against the installed build.

## Is this a breaking change?

No.

## Does this PR require a documentation update?

`NEWS.md` is updated as described.

## Checklist

- [x] Tests pass locally (`devtools::test()`)
- [x] Documentation regenerated if roxygen comments changed
- [x] Code is formatted with [air](https://posit-dev.github.io/air/)
- [x] A `NEWS.md` bullet added under `# (development version)` for any user-facing change
- [x] I have read and understood every change I am submitting, and tested it myself
