### PR TITLE
chore: begin the 0.3.0.9000 development cycle

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: anicheck
 Type: Package
 Title: An R package for diagnosing movement data quality
-Version: 0.3.0
+Version: 0.3.0.9000
 Authors@R: 
     person(
       "Mikkel", 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# anicheck (development version)
+
 # anicheck 0.3.0 (2026-08-28)
 
 ## Changed


### PR DESCRIPTION
## Description

### What kind of change is this?

- [ ] Bug fix
- [ ] Addition of a new feature
- [ ] Documentation
- [x] Maintenance (CI, dependencies, refactoring)
- [ ] Other

### Why is it needed?

The \`After\` step of the release checklist. anicheck 0.3.0 is tagged and released, so \`DESCRIPTION\` moves past it and \`NEWS.md\` opens a section for what follows.

### What does it do?

\`DESCRIPTION\` goes to \`0.3.0.9000\`, and \`NEWS.md\` gains a \`# anicheck (development version)\` heading above the released section.

\`README.md\` embeds no version here, so it needs no re-render.

## How has this PR been tested?

No code changes — version metadata and a changelog heading.

## Is this a breaking change?

No.

## Checklist

- [x] I have read and understood every change I am submitting