### PR TITLE
feat: use Red as the site accent colour

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -7,6 +7,8 @@ home:
 template:
   bootstrap: 5
   package: animovementtemplate
+  bslib:
+    primary: "#CE4441"
 
 reference:
 - title: "Diagnostics"


### PR DESCRIPTION
## Description

### What kind of change is this?

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Documentation
- [ ] Maintenance (CI, dependencies, refactoring)
- [ ] Other

Website appearance, so documentation in the loose sense — no R code changes.

### Why is it needed?

Every site in the suite currently uses Bootstrap's default blue, so the hex on
the home page and the links beneath it have nothing to do with each other. This
gives the site the package's own identity colour, Red (#CE4441), the one
`palette.py` assigns it in the brand repo.

### What does it do?

Sets `primary` in the site's `bslib` config, which is what pkgdown derives link
and accent colours from. The shared template is untouched and still inherited —
package config merges over it rather than replacing it.

Both themes clear AA on the hue alone, so no link overrides are needed.

## References

The colour is `PACKAGES` in animovement/brand. Companion changes doing the same
for the other seven sites.

## How has this PR been tested?

Rendered locally — `pkgdown::init_site()` + `build_home()` against the template —
and the link colours read out of the compiled CSS and checked for contrast:

| | colour | on background |
|---|---|---|
| light | `#CE4441` | 4.64:1 |
| dark | `#e28f8d` | 6.28:1 |

## Is this a breaking change?

No.

## Does this PR require a documentation update?

No.

## Checklist

- [ ] Tests pass locally (`devtools::test()`) — not affected, site config only
- [ ] Tests have been added covering new functionality — n/a
- [ ] Documentation regenerated if roxygen comments changed — n/a
- [ ] Code is formatted with air — n/a, no R code changed
- [ ] A `NEWS.md` bullet added — no user-facing package change
- [x] I have read and understood every change I am submitting, and tested it myself

---

Written with Claude Code; the commit carries a `Co-Authored-By:` trailer.
